### PR TITLE
Remove byte array allocation and wrap the destination buffer in an ar…

### DIFF
--- a/Memcached/PooledSocket.cs
+++ b/Memcached/PooledSocket.cs
@@ -250,16 +250,19 @@ namespace Enyim.Caching.Memcached
 			this.CheckDisposed();
 			var total = 0;
 			var should = count;
+			var into = new ArraySegment<byte>(buffer, 0, should);
 			while (total < count)
 				try
 				{
-					var into = new ArraySegment<byte>(new byte[should], 0, should);
-					var read = await this._socket.ReceiveAsync(into, SocketFlags.None).WithCancellationToken(cancellationToken).ConfigureAwait(false);
-					if (read > 0)
-						Buffer.BlockCopy(into.Array, 0, buffer, offset, read);
+					var read = await this._socket.ReceiveAsync(into, SocketFlags.None)
+												 .WithCancellationToken(cancellationToken)
+												 .ConfigureAwait(false);
+
 					total += read;
 					offset += read;
 					should -= read;
+
+					into = new ArraySegment<byte>(buffer, offset, should);
 				}
 				catch (OperationCanceledException)
 				{


### PR DESCRIPTION
Removed the explicit byte array allocation and buffer block copy that was happening in every iteration of ReceiveAsync. Based on dump files in PerfView there was a lot of new Array allocations that were going to the Large Object Heap. My guess is our code probably has some things being serialized greater than the socket.ReceiveBufferSize and the while loop is having to pull from the socket over multiple iterations. I tested this out locally just wrapping the destination array in an arraysegment and then creating new ArraySegments based off the offset and remaining count and it still worked correctly on small objects and ones that were greater than the ReceiveBufferSize of the socket. If anything looks wrong let me know and I can fix. Thanks.